### PR TITLE
Removes Wayland socket because it doesn't start in Wayland

### DIFF
--- a/org.purei.Play.yaml
+++ b/org.purei.Play.yaml
@@ -6,8 +6,7 @@ command: Play
 finish-args:
   - --share=ipc
   - --share=network
-  - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --filesystem=home:ro
   - --filesystem=/mnt:ro
   - --filesystem=/media:ro


### PR DESCRIPTION
Removes Wayland socket because it doesn't start in Wayland. It works fine in Xwayland though.